### PR TITLE
Fixed bug: "05 (0x05) Write Single Coil"

### DIFF
--- a/ModbusLib/Protocols/Modbus/Codecs/ModbusCodecWriteSingleDiscrete.cs
+++ b/ModbusLib/Protocols/Modbus/Codecs/ModbusCodecWriteSingleDiscrete.cs
@@ -75,9 +75,7 @@ namespace ModbusLib.Protocols
             command.QueryTotalLength += 2;
 
             command.Data = new ushort[1];
-            command.Data[0] = body.ReadUInt16BE() != 0
-                ? (ushort)0xFFFF
-                : (ushort)0;
+            command.Data[0] = body.ReadUInt16BE();
         }
 
         #endregion


### PR DESCRIPTION
The response should echo back the written value. This was drawn from the
decoded command, which used `0xFFFF` for truthy representation instead
of the `0xFF00` that the Modbus standard specifies. The decoder now no
longer makes such a conversion and just copies the written value
instead.